### PR TITLE
Fix qclean.js removeADsLink typo

### DIFF
--- a/QCLean-Chrome/qclean.js
+++ b/QCLean-Chrome/qclean.js
@@ -10,7 +10,7 @@ qclean.removeADsLink = function(){
             target.parentNode.removeChild(target);
             console.log('Remove ads');
         }
-        adsLinkk = document.getElementsByClassName("adsCategoryTitleLink");
+        adsLink = document.getElementsByClassName("adsCategoryTitleLink");
     }
 };
 


### PR DESCRIPTION
the code:
    adsLink = document.getElementsByClassName("adsCategoryTitleLink");
was written as
    adsLinkk = document.getElementsByClassName("adsCategoryTitleLink");
causing the script to loop forever.
