### PR TITLE
Fix the like, comment function when click-to-open show the post

### DIFF
--- a/QCLean-Chrome-Experiment/qclean.js
+++ b/QCLean-Chrome-Experiment/qclean.js
@@ -299,9 +299,10 @@ qclean.framework._hideElementByTargetChild = function(target, featureDesc){
                         } else if (reason == "screenshot") {
                             reasonText = "螢幕截圖";
                         }
-                        var html = "<div id='pokemonPost' class='qcleanTextCenter qcleanClickable'><p>疑似 Pokemon Go 貼文（"+reasonText+"），點我可展開貼文。</div>";
-                        target.firstChild.innerHTML = html + target.firstChild.innerHTML;
-                        var clickToOpenDiv = target.querySelector("#pokemonPost");
+                        var clickToOpenDiv = document.createElement("div");
+                        clickToOpenDiv.classList.add("qcleanTextCenter", "qcleanClickable");
+                        clickToOpenDiv.innerHTML = "<p>疑似 Pokemon Go 貼文（"+reasonText+"），點我可展開貼文。</p>";
+                        target.firstChild.insertBefore(clickToOpenDiv, target.firstChild.firstChild);
                         clickToOpenDiv.onclick = function(event) {
                             event.preventDefault();
                             console.log("click to open!");


### PR DESCRIPTION
Issue detail description:
When the `clickToOpenDiv` is clicked, it shows the hiddens.  However, the hiddens can not do like, comment action. The event handler (eg: send like POST) listen to the action icon is disappeared.

Why:
```
target.firstChild.innerHTML = html + target.firstChild.innerHTML;
```

This code will **recreate** the inner DOM, thus lose all of the binding events

Fix:
Prepend the desire DOM to the `target.firstChild`